### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 composer.phar
 vendor/
 dist/
+.idea
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 # composer.lock


### PR DESCRIPTION
Listed in #47. 

Set `.idea` to `.gitignore` So the contributors that use Phpstorm doesn't need to be worried of their .idea files.
